### PR TITLE
feat: group posts by month in nav sidebar

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,20 @@
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("css");
 
+  // Sorted collection: posts by date, newest first
+  eleventyConfig.addCollection("postsByDate", function(collectionApi) {
+    return collectionApi.getFilteredByTag("posts").sort((a, b) => {
+      return b.date - a.date;
+    });
+  });
+
+  // Filter to format date as "MMM YYYY"
+  eleventyConfig.addFilter("monthYear", function(date) {
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    return months[date.getMonth()] + " " + date.getFullYear();
+  });
+
   return {
     dir: {
       output: "docs",

--- a/css/style.css
+++ b/css/style.css
@@ -41,6 +41,31 @@ body {
   border-right: 1px solid #ccc;
 }
 
+.nav-month {
+  font-size: 0.75em;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.nav-month:first-child {
+  margin-top: 0;
+}
+
+.nav-post {
+  display: block;
+  padding: 0.25rem 0;
+  padding-left: 0.5rem;
+  text-decoration: none;
+  color: #333;
+}
+
+.nav-post:hover {
+  color: #000;
+}
+
 .main {
   grid-area: main;
   overflow-y: auto;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -41,6 +41,31 @@ body {
   border-right: 1px solid #ccc;
 }
 
+.nav-month {
+  font-size: 0.75em;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.nav-month:first-child {
+  margin-top: 0;
+}
+
+.nav-post {
+  display: block;
+  padding: 0.25rem 0;
+  padding-left: 0.5rem;
+  text-decoration: none;
+  color: #333;
+}
+
+.nav-post:hover {
+  color: #000;
+}
+
 .main {
   grid-area: main;
   overflow-y: auto;

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,9 +13,7 @@
       <p class="subtitle">Dev log - <a href="/">About</a></p>
       <div class="separator"></div>
     </header>
-    <nav class="nav">
-      <ul><li><a href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a></li><li><a href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a></li><li><a href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></li></ul>
-    </nav>
+    <nav class="nav"><div class="nav-month">Sep 2025</div><a class="nav-post" href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a><a class="nav-post" href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a><a class="nav-post" href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></nav>
     <main class="main">
       <p>Hello! I'm Surya Susarla, a software engineer at AWS specializing in backend services and Gen AI. I'm passionate about building scalable, high-performance systems and contributing to open source. My interests also extend to the AI space, where I explore creating utilities to enhance software services. I hold a Master's in Computer Science from North Carolina State University and previously worked at Microsoft on the Edge browser.</p>
 <p>Outside of work, I'm an avid gamer, enjoying simulators, single-player, and sports titles. I also love road trips and driving.</p>

--- a/docs/posts/agent-sh-instant-llm-ops/index.html
+++ b/docs/posts/agent-sh-instant-llm-ops/index.html
@@ -13,9 +13,7 @@
       <p class="subtitle">Dev log - <a href="/">About</a></p>
       <div class="separator"></div>
     </header>
-    <nav class="nav">
-      <ul><li><a href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a></li><li><a href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a></li><li><a href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></li></ul>
-    </nav>
+    <nav class="nav"><div class="nav-month">Sep 2025</div><a class="nav-post" href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a><a class="nav-post" href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a><a class="nav-post" href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></nav>
     <main class="main">
       <h1>Agent.sh — Instant LLM Ops On Any Shell</h1>
 <p>I’ve always wanted a way to drop onto a random Linux box—fresh Arch VM, prod bastion, whatever—and get LLM superpowers without installing half the internet first. Agent.sh is the answer: a single Bash script that spins up a REPL, proxies an OpenAI-compatible chat endpoint, and can execute shell commands (with my approval) on demand. No daemons, no Python runtimes, no magical background services—just curl, jq, and the terminal.</p>

--- a/docs/posts/revisiting-bloom-filters/index.html
+++ b/docs/posts/revisiting-bloom-filters/index.html
@@ -13,9 +13,7 @@
       <p class="subtitle">Dev log - <a href="/">About</a></p>
       <div class="separator"></div>
     </header>
-    <nav class="nav">
-      <ul><li><a href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a></li><li><a href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a></li><li><a href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></li></ul>
-    </nav>
+    <nav class="nav"><div class="nav-month">Sep 2025</div><a class="nav-post" href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a><a class="nav-post" href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a><a class="nav-post" href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></nav>
     <main class="main">
       <h1>Revisiting Bloom Filters</h1>
 <h3>Background</h3>

--- a/docs/posts/setting-up-this-blog/index.html
+++ b/docs/posts/setting-up-this-blog/index.html
@@ -13,9 +13,7 @@
       <p class="subtitle">Dev log - <a href="/">About</a></p>
       <div class="separator"></div>
     </header>
-    <nav class="nav">
-      <ul><li><a href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a></li><li><a href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a></li><li><a href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></li></ul>
-    </nav>
+    <nav class="nav"><div class="nav-month">Sep 2025</div><a class="nav-post" href="/posts/revisiting-bloom-filters/">Revisiting Bloom Filters - 21 Sep 2025</a><a class="nav-post" href="/posts/agent-sh-instant-llm-ops/">Agent.sh — Instant LLM Ops On Any Shell</a><a class="nav-post" href="/posts/setting-up-this-blog/">Setting up this page - 20 Sep 2025</a></nav>
     <main class="main">
       <h1>Why?</h1>
 <p>For a long time I've been meaning to do something like this, a place for me to just collect all my experiments. There are a a lot of new things everyday and I barely get to try 1% of them. And the 1% I do try, I forget about them and move on to the next ones. I've tried creating github repositories etc. but in complete honesty, the only usable outcome of these experiments is some intuition of the concept in the worst case and a learning I'll carry with me in the best case. So, long story short, these notes are just a thought log of things I've tried, experimented, learned from and just found interesting.</p>

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -14,11 +14,15 @@
       <div class="separator"></div>
     </header>
     <nav class="nav">
-      <ul>
-        {%- for post in collections.posts -%}
-          <li><a href="{{ post.url }}">{{ post.data.title }}</a></li>
-        {%- endfor -%}
-      </ul>
+      {%- set currentMonth = "" -%}
+      {%- for post in collections.postsByDate -%}
+        {%- set postMonth = post.date | monthYear -%}
+        {%- if postMonth != currentMonth -%}
+          {%- set currentMonth = postMonth -%}
+          <div class="nav-month">{{ postMonth }}</div>
+        {%- endif -%}
+        <a class="nav-post" href="{{ post.url }}">{{ post.data.title }}</a>
+      {%- endfor -%}
     </nav>
     <main class="main">
       {{ content | safe }}

--- a/posts/agent-sh-instant-llm-ops.md
+++ b/posts/agent-sh-instant-llm-ops.md
@@ -2,6 +2,7 @@
 layout: base.njk
 title: Agent.sh — Instant LLM Ops On Any Shell
 tags: posts
+date: 2025-09-20
 ---
 
 # Agent.sh — Instant LLM Ops On Any Shell

--- a/posts/revisiting-bloom-filters.md
+++ b/posts/revisiting-bloom-filters.md
@@ -2,6 +2,7 @@
 layout: base.njk
 title: Revisiting Bloom Filters - 21 Sep 2025
 tags: posts
+date: 2025-09-21
 ---
 
 # Revisiting Bloom Filters

--- a/posts/setting-up-this-blog.md
+++ b/posts/setting-up-this-blog.md
@@ -2,6 +2,7 @@
 layout: base.njk
 title: Setting up this page - 20 Sep 2025
 tags: posts
+date: 2025-09-20
 ---
 
 # Why?


### PR DESCRIPTION
## Summary
- Adds Medium-style month groupings to the nav sidebar
- Posts sorted newest-first within each month
- Subtle month headers (e.g., "Sep 2025") with posts nested underneath

## Changes
- Added `date` field to all post frontmatter
- Created `postsByDate` collection in Eleventy config
- Updated nav template to group by month/year
- Added CSS for month headers and post links

## Test plan
- [x] Run `npm run start` and verify nav shows month headers
- [x] Verify posts appear newest-first
- [x] Check mobile responsive layout

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)